### PR TITLE
Add support for showing modal in edit vs create interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In order to run demo locally, clone the repo and run:
   npm install moment --save
   ```
 
-  ##Usage
+  ## Usage
 
   You need to import the component and styles in your application as follows:
 
@@ -40,7 +40,7 @@ import 'react-week-calendar/dist/style.less';
  ```
 
 
- ###Props
+ ### Props
 
  | Property | Type | Default | Description
  :---|:---|:--- |:---
@@ -63,6 +63,7 @@ import 'react-week-calendar/dist/style.less';
  | `onEventClick` | func |  | |
  | `modalComponent` | ReactComponent | [Modal](https://github.com/birik/react-week-calendar/blob/master/src/Modal.js) | The react component that gets used for rendering of modal |
  | `useModal` | bool | true | If false, after selection of the intervals the modal will be not shown and intervals will send back |
+ | `showModalCase` | array | ['create', 'edit'] | Cases in which to show the modal (create new interval vs. edit existing interval)
  | `eventSpacing` | number | 15 |The amount of horizontal space (in pixels) between events|
 
 If you want to change the styles of the component, you should overwrite the less variable. For example:

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -11,16 +11,12 @@ const propTypes = {
 };
 
 class DayColumn extends React.Component {
-  handleMouseEnter = (col, row) => {
-    return () => {
-      this.props.onCellMouseEnter(col, row);
-    };
+  handleMouseEnter = (col, row) => () => {
+    this.props.onCellMouseEnter(col, row);
   }
 
-  handleStartSelection = (col, row) => {
-    return () => {
-      this.props.onSelectionStart(col, row);
-    };
+  handleStartSelection = (col, row) => () => {
+    this.props.onSelectionStart(col, row);
   }
 
   render() {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -7,6 +7,7 @@ const propTypes = {
   value: PropTypes.string,
   onRemove: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
+  actionType: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
 };
 
 const defaultProps = {

--- a/src/WeekCalendar.js
+++ b/src/WeekCalendar.js
@@ -364,8 +364,8 @@ class WeekCalendar extends React.Component {
   }
 
   renderModal() {
-    const { useModal } = this.props;
-    const { preselectedInterval, showModalCase } = this.state;
+    const { useModal, showModalCase } = this.props;
+    const { preselectedInterval } = this.state;
 
     const isEditingExistingInterval = preselectedInterval && preselectedInterval.value;
     const isCreatingNewInterval = preselectedInterval && !preselectedInterval.value;

--- a/src/WeekCalendar.js
+++ b/src/WeekCalendar.js
@@ -35,7 +35,7 @@ const propTypes = {
   onEventClick: PropTypes.func,
 
   modalComponent: PropTypes.func,
-  useModal: PropTypes.bool,
+  useModal: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]), // bool - always display or never display, object - conditionally for create vs. delete
   eventSpacing: PropTypes.number,
 };
 
@@ -192,7 +192,7 @@ class WeekCalendar extends React.Component {
       .minute(endSelectionTime.minute())
       .second(0);
 
-    if (useModal) {
+    if (useModal === true || useModal.forCreateInterval === true) {
       const preselectedInterval = {
         start,
         end,
@@ -362,6 +362,11 @@ class WeekCalendar extends React.Component {
   renderModal() {
     const { useModal } = this.props;
     const { preselectedInterval } = this.state;
+    const isExistingInterval = preselectedInterval && preselectedInterval.uid;
+    if (useModal && useModal.forDeleteInterval === false && isExistingInterval) {
+      return;
+    }
+
     if (useModal && preselectedInterval) {
       const ModalComponent = this.props.modalComponent;
       return (

--- a/src/WeekCalendar.js
+++ b/src/WeekCalendar.js
@@ -368,8 +368,13 @@ class WeekCalendar extends React.Component {
     const { useModal, showModalCase } = this.props;
     const { preselectedInterval } = this.state;
 
-    const isEditingExistingInterval = preselectedInterval && preselectedInterval.hasOwnProperty('uid');
-    const isCreatingNewInterval = preselectedInterval && !preselectedInterval.hasOwnProperty('value') && !preselectedInterval.hasOwnProperty('uid');
+    const isEditingExistingInterval = preselectedInterval
+      && Object.prototype.hasOwnProperty.call(preselectedInterval, 'uid');
+
+    const isCreatingNewInterval = preselectedInterval
+      && !Object.prototype.hasOwnProperty.call(preselectedInterval, 'value')
+      && !Object.prototype.hasOwnProperty.call(preselectedInterval, 'uid');
+
     const shouldRenderModal = useModal
       && ((isEditingExistingInterval && showModalCase.includes(ACTION_TYPES.EDIT))
       || (isCreatingNewInterval && showModalCase.includes(ACTION_TYPES.CREATE)));

--- a/src/WeekCalendar.js
+++ b/src/WeekCalendar.js
@@ -161,6 +161,7 @@ class WeekCalendar extends React.Component {
       firstDay,
       scaleUnit,
       useModal,
+      showModalCase,
     } = this.props;
     const {
       startSelectionPosition,
@@ -196,7 +197,7 @@ class WeekCalendar extends React.Component {
       .minute(endSelectionTime.minute())
       .second(0);
 
-    if (useModal) {
+    if (useModal && showModalCase.includes(ACTION_TYPES.CREATE)) {
       const preselectedInterval = {
         start,
         end,
@@ -367,8 +368,8 @@ class WeekCalendar extends React.Component {
     const { useModal, showModalCase } = this.props;
     const { preselectedInterval } = this.state;
 
-    const isEditingExistingInterval = preselectedInterval && preselectedInterval.value;
-    const isCreatingNewInterval = preselectedInterval && !preselectedInterval.value;
+    const isEditingExistingInterval = preselectedInterval && preselectedInterval.hasOwnProperty('uid');
+    const isCreatingNewInterval = preselectedInterval && !preselectedInterval.hasOwnProperty('value') && !preselectedInterval.hasOwnProperty('uid');
     const shouldRenderModal = useModal
       && ((isEditingExistingInterval && showModalCase.includes(ACTION_TYPES.EDIT))
       || (isCreatingNewInterval && showModalCase.includes(ACTION_TYPES.CREATE)));

--- a/src/WeekCalendar.js
+++ b/src/WeekCalendar.js
@@ -369,9 +369,9 @@ class WeekCalendar extends React.Component {
 
     const isEditingExistingInterval = preselectedInterval && preselectedInterval.value;
     const isCreatingNewInterval = preselectedInterval && !preselectedInterval.value;
-    const shouldRenderModal = (useModal && preselectedInterval)
-      || (isEditingExistingInterval && showModalCase.includes(ACTION_TYPES.EDIT))
-      || (isCreatingNewInterval && showModalCase.includes(ACTION_TYPES.CREATE));
+    const shouldRenderModal = useModal
+      && ((isEditingExistingInterval && showModalCase.includes(ACTION_TYPES.EDIT))
+      || (isCreatingNewInterval && showModalCase.includes(ACTION_TYPES.CREATE)));
 
     if (shouldRenderModal) {
       const ModalComponent = this.props.modalComponent;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,9 @@
+/**
+ * Generic constants for the calendar.
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export const ACTION_TYPES = {
+  CREATE: 'create',
+  EDIT: 'edit',
+};


### PR DESCRIPTION
Hey there @birik! Thanks for this awesome module!

Our application would like to only show the modal for deleting intervals, and create interval would just automatically book the slot.

Not particularly happy with my implementation =/, but I tried to do it in a non-breaking change. Would appreciate any feedback if you have opinions on this. 

If the approach looks reasonable to you, I will add corresponding tests (it passes the existing tests).

**Note:** I will also update the documentation and can add in an example of usage, just wanted to make sure we agree on an implementation first.